### PR TITLE
修改硬盘占用百分比不显示/不正确

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -481,8 +481,9 @@ func GetMemPercent() float64 {
 }
 
 func GetDiskPercent() float64 {
-	parts, _ := disk.Partitions(true)
-	diskInfo, _ := disk.Usage(parts[0].Mountpoint)
+//	parts, _ := disk.Partitions(true)
+//	diskInfo, _ := disk.Usage(parts[0].Mountpoint)
+	diskInfo, _ := disk.Usage(info.DownloadFolder)
 	return diskInfo.UsedPercent
 }
 


### PR DESCRIPTION
### 解决此 issue：[issues/26](https://github.com/gaowanliang/DownloadBot/issues/26)
> 使用DownloadFolder作为disk.Usage参数，可解决硬盘占用百分比无示数、挂载的硬盘不能被计算入硬盘占用等问题